### PR TITLE
Fix: Stepper가 체크 아이콘을 제대로 표시하도록 수정

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,1 +1,1 @@
-module.exports = 'test-file-stub';
+module.exports = 'stub-file';

--- a/src/js/components/Stepper/step.test.tsx
+++ b/src/js/components/Stepper/step.test.tsx
@@ -30,7 +30,7 @@ export default describe('Step Default', () => {
       state: 'resolved',
       index: index + 1,
     });
-    expect(wrapper.find(StepSymbol).text()).toEqual('test-file-stub');
+    expect(wrapper.find(StepSymbol).find('div').prop('dangerouslySetInnerHTML')).toEqual({ __html: 'stub-file' });
   });
 
   // TODO: state에 따라 스타일 제대로 들어가는지 테스트

--- a/src/js/components/Stepper/step.tsx
+++ b/src/js/components/Stepper/step.tsx
@@ -14,11 +14,11 @@ interface StepSymbolProps {
 
 /**
  * 각 step의 Symbol symbol prop으로 표시할 값을 넘긴다.
- * symbol이 number, string이 아니면 html에 넣을 수 있는 값(svg)으로 간주
+ * symbol이 number 이면 index, string이면 html에 넣을 수 있는 값(svg)으로 간주
  * @param props {StepIndexProps}
  */
 export const StepSymbol = styled((props: StepSymbolProps) => {
-  return ['number', 'string'].includes(typeof props.symbol)
+  return typeof props.symbol === 'number'
     ? (<div className={props.className}>{props.symbol}</div>)
     : (<div className={props.className} dangerouslySetInnerHTML={{ __html: props.symbol }} />);
 })`


### PR DESCRIPTION
svg 파일을 임포트 하면 string으로 다뤄지기 때문에 분기가 잘못 이뤄지고 있었습니다.
이를 감지할 수 있는 테스트케이스를 작성하였고, 문제를 수정했습니다.